### PR TITLE
Trying out direct merge of the @wordpress/eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	"author": "Seth Rubenstein <srubenstein@pewresearch.org> (https://www.pewresearch.org)",
 	"license": "MIT",
 	"bugs": {
-	  "url": "https://github.com/pewresearch/code-style-guide/issues"
+		"url": "https://github.com/pewresearch/code-style-guide/issues"
 	},
-	"homepage": "https://github.com/pewresearch/code-style-guide"
-  }
+	"homepage": "https://github.com/pewresearch/code-style-guide",
+	"dependencies": {}
+}

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,4 @@
+## Naming of Packages
+
+- For internal private packages, apis, and hooks prefix with `@prc-{app|block-library|block-plugins|quiz}`
+- For external public packages and apis prefix with `@pewresearch`

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,1 +1,0 @@
-../../javascript/README.md

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,5 +14,6 @@ module.exports = {
 			message: "Use @wordpress/element instead."
 		}],
 		"indent": ["error", "tab"],
+		"react/react-in-jsx-scope": "off",
 	},
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,7 +12,7 @@ module.exports = {
 		'import/no-extraneous-dependencies': 0,
 		'no-restricted-imports': ["error", {
 			name: "react",
-			message: "Use @wordpress/element instead."
+			message: "You are developing an application for use inside WordPress, use @wordpress/element instead."
 		}],
 		// React
 		'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -16,9 +16,8 @@ module.exports = {
 		}],
 		// React
 		'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
-		// 'react/forbid-prop-types': [0, { forbid: ['any'] }],
 		'react/prop-types': 0,
 		'react/react-in-jsx-scope': 0,
-		// 'react/jsx-props-no-spreading': 0,
+		'react/jsx-props-no-spreading': 0,
 	},
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -3,17 +3,22 @@ module.exports = {
 	plugins: ['prettier', 'react'],
 	rules: {
 		'prettier/prettier': 'error',
+		"indent": ["error", "tab"],
+		// Code Style
 		'yoda': ["error", "always"],
 		'function-paren-newline': ["error"],
 		'comma-dangle': ["error", "only-multiline"],
+		// Imports
 		'import/no-extraneous-dependencies': 0,
-		// disallow specific imports
-		// https://eslint.org/docs/rules/no-restricted-imports
 		'no-restricted-imports': ["error", {
 			name: "react",
 			message: "Use @wordpress/element instead."
 		}],
-		"indent": ["error", "tab"],
-		"react/react-in-jsx-scope": "off",
+		// React
+		'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+		// 'react/forbid-prop-types': [0, { forbid: ['any'] }],
+		'react/prop-types': 0,
+		'react/react-in-jsx-scope': 0,
+		// 'react/jsx-props-no-spreading': 0,
 	},
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ["airbnb", "prettier"],
+	extends: ["airbnb", "plugin:@wordpress/eslint-plugin/recommended", "prettier"],
 	plugins: ['prettier', 'react'],
 	rules: {
 		'prettier/prettier': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,6 +27,7 @@
 	},
 	"homepage": "https://github.com/pewresearch/code-style-guide",
 	"dependencies": {
+		"@wordpress/eslint-plugin": "^11.1.0",
 		"eslint": "^8.11.0",
 		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-prettier": "^8.5.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pewresearch/eslint-config",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Pew Research Center's eslint configuration",
 	"main": "index.json",
 	"repository": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pewresearch/eslint-config",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Pew Research Center's eslint configuration",
 	"main": "index.json",
 	"repository": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pewresearch/eslint-config",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Pew Research Center's eslint configuration",
 	"main": "index.json",
 	"repository": {

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,4 +1,5 @@
 {
+	"schema": "https://getcomposer.org/schema.json",
     "require-dev": {
         "automattic/vipwpcs": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"


### PR DESCRIPTION
- Update org
- Create readme symlink for package publish
- updates
- v1.0.1
- Damn, you cant symlink a readme in a repo on package publish
- Bring in some updates
- v1.0.2
- Allow prop spreading
- v1.0.3
- Add context for use of @wordpress/element
- Defining nomenclature for internal vs external  package naming
- Lets try this combo chaos out
