### PR TITLE
Rever those changes

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ["airbnb", "plugin:@wordpress/eslint-plugin/recommended", "prettier"],
+	extends: ["airbnb", "prettier"],
 	plugins: ['prettier', 'react'],
 	rules: {
 		'prettier/prettier': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pewresearch/eslint-config",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Pew Research Center's eslint configuration",
 	"main": "index.json",
 	"repository": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,7 +27,6 @@
 	},
 	"homepage": "https://github.com/pewresearch/code-style-guide",
 	"dependencies": {
-		"@wordpress/eslint-plugin": "^11.1.0",
 		"eslint": "^8.11.0",
 		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
- Update org
- Create readme symlink for package publish
- updates
- v1.0.1
- Damn, you cant symlink a readme in a repo on package publish
- Bring in some updates
- v1.0.2
- Allow prop spreading
- v1.0.3
- Add context for use of @wordpress/element
- Defining nomenclature for internal vs external  package naming
- Lets try this combo chaos out
- v1.0.4
- Revert this change
